### PR TITLE
Private dev users

### DIFF
--- a/src/main/java/codeu/model/data/Conversation.java
+++ b/src/main/java/codeu/model/data/Conversation.java
@@ -128,15 +128,17 @@ public class Conversation {
   public HashMap<UUID, Boolean> getAllowedUsers() {
     return allowedUsers; 
   }
-  
+
   /* Returns true if user is allowed in private conversation */
   public boolean isAllowedUser(UUID id) {
       return allowedUsers.containsKey(id); 
   }
 
-  /* Returns true if  user is an admin */
+  /* Returns true if user is an admin */
   public boolean isAdmin(UUID id) {
-    return allowedUsers.get(id); 
+    if (allowedUsers.containsKey(id))
+      return allowedUsers.get(id); 
+    return false; 
   }
 
   /* schedules a surprise at specified time for user id to be added into this conversation */

--- a/src/main/java/codeu/model/data/Conversation.java
+++ b/src/main/java/codeu/model/data/Conversation.java
@@ -46,7 +46,7 @@ public class Conversation {
 
     public void run() {
         System.out.println("User" + id + " surprised!"); // change to send alert to notification class 
-        existingUsers.put(id, true); 
+        allowedUsers.put(id, true); 
         scheduledSurprises.remove(id); 
         timer.cancel(); 
     }
@@ -55,7 +55,7 @@ public class Conversation {
   // maps existing allowed users and whether or not they are admins 
   // default admin privileges set to true
   // null if type == "public"
-  private HashMap<UUID, Boolean> existingUsers; 
+  public HashMap<UUID, Boolean> allowedUsers; 
 
   // timer to keep track of TimerTasks
   private Timer timer; 
@@ -71,6 +71,7 @@ public class Conversation {
    * @param title the title of this Conversation
    * @param creation the creation time of this Conversation
    * @param type the type (public/private) of this Conversation
+   * @param allowedUsers the list of users with access to this Conversation
    */
   public Conversation(UUID id, UUID owner, String title, Instant creation, String type) {
     this.id = id;
@@ -82,11 +83,11 @@ public class Conversation {
     if (type != null && type.equals("private")) {
       timer = new Timer(); 
       scheduledSurprises = new HashMap<UUID, SurpriseTask>(); 
-      existingUsers = new HashMap<UUID, Boolean>(); 
-      existingUsers.put(owner, true); 
+      allowedUsers = new HashMap<UUID, Boolean>(); 
+      allowedUsers.put(owner, true); 
     }
     else {
-      existingUsers = null; 
+      allowedUsers = null; 
       timer = null; 
       scheduledSurprises = null; 
     }
@@ -124,21 +125,25 @@ public class Conversation {
     return type;
   }
 
+  public HashMap<UUID, Boolean> getAllowedUsers() {
+    return allowedUsers; 
+  }
+  
   /* Returns true if user is allowed in private conversation */
   public boolean isAllowedUser(UUID id) {
-      return existingUsers.containsKey(id); 
+      return allowedUsers.containsKey(id); 
   }
 
   /* Returns true if  user is an admin */
   public boolean isAdmin(UUID id) {
-    return existingUsers.get(id); 
+    return allowedUsers.get(id); 
   }
 
-    /* schedules a surprise at specified time for user id to be added into this conversation */
-    public void scheduleSurprise(UUID id, Date time) {
-      SurpriseTask surprise = new SurpriseTask(id);  
-      timer.schedule(surprise, time); 
-      scheduledSurprises.put(id, surprise); 
+  /* schedules a surprise at specified time for user id to be added into this conversation */
+  public void scheduleSurprise(UUID id, Date time) {
+    SurpriseTask surprise = new SurpriseTask(id);  
+    timer.schedule(surprise, time); 
+    scheduledSurprises.put(id, surprise); 
   }
 
   /* checks surprise time of user id */
@@ -149,9 +154,13 @@ public class Conversation {
       return cal; 
   }
 
-  /* adds user id to existing users with admin privileges */
+  /* adds user id to allowed users */
   public void addUser(UUID id) {
-      existingUsers.put(id, true); 
+      allowedUsers.put(id, false); 
+  }
+
+  public void addAdmin(UUID id) {
+    allowedUsers.put(id, true); 
   }
 
   /* checks if any surprises should have happened but have not yet, and returns false if so, may be useful for debugging */

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -19,7 +19,6 @@ import codeu.model.data.Conversation;
 import codeu.model.data.Message;
 import codeu.model.data.Profile;
 import codeu.model.data.User;
-import sun.jvm.hotspot.debugger.posix.elf.ELFSectionHeader;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;

--- a/src/test/java/codeu/model/data/ConversationTest.java
+++ b/src/test/java/codeu/model/data/ConversationTest.java
@@ -52,5 +52,34 @@ public class ConversationTest {
     Assert.assertEquals(title, conversation.getTitle());
     Assert.assertEquals(creation, conversation.getCreationTime());
     Assert.assertEquals(type, conversation.getType()); 
+    Assert.assertEquals(true, conversation.isAdmin(owner));
+  }
+
+  @Test
+  public void testAddUsers() {
+    UUID id = UUID.randomUUID();
+    UUID owner = UUID.randomUUID();
+    String title = "Test_Title";
+    Instant creation = Instant.now();
+    String type = "private"; 
+    UUID idOne = UUID.randomUUID(); 
+    UUID idTwo = UUID.randomUUID(); 
+    UUID idAdmin = UUID.randomUUID(); 
+
+    Conversation conversation = new Conversation(id, owner, title, creation, type);
+    conversation.addUser(idOne); 
+    conversation.addAdmin(idAdmin); 
+
+    Assert.assertEquals(id, conversation.getId());
+    Assert.assertEquals(owner, conversation.getOwnerId());
+    Assert.assertEquals(title, conversation.getTitle());
+    Assert.assertEquals(creation, conversation.getCreationTime());
+    Assert.assertEquals(type, conversation.getType()); 
+
+    Assert.assertEquals(true, conversation.isAdmin(owner)); 
+    Assert.assertEquals(true, conversation.isAllowedUser(idOne));
+    Assert.assertEquals(false, conversation.isAllowedUser(idTwo));  
+    Assert.assertEquals(true, conversation.isAdmin(idAdmin));
+    Assert.assertEquals(false, conversation.isAdmin(idOne));
   }
 }

--- a/src/test/java/codeu/model/store/basic/ConversationStoreTest.java
+++ b/src/test/java/codeu/model/store/basic/ConversationStoreTest.java
@@ -92,6 +92,12 @@ public class ConversationStoreTest {
     Assert.assertEquals(
         expectedConversation.getCreationTime(), actualConversation.getCreationTime());
     Assert.assertEquals(
-      expectedConversation.getType(), actualConversation.getType()); 
+      expectedConversation.getType(), actualConversation.getType());
+    if (expectedConversation.getType().equals("private")) {
+      for (UUID id : expectedConversation.getAllowedUsers().keySet()) {
+        assert(expectedConversation.isAllowedUser(id) == actualConversation.isAllowedUser(id)); 
+        assert(expectedConversation.isAdmin(id) == actualConversation.isAdmin(id)); 
+      }
+    }
   }
 }

--- a/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
@@ -12,6 +12,7 @@ import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import java.util.HashMap;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -89,7 +90,12 @@ public class PersistentDataStoreTest {
     String titleTwo = "Test_Title_Two";
     Instant creationTwo = Instant.ofEpochMilli(2000);
     String typeTwo = "private"; 
+    HashMap<UUID, Boolean> allowedUsersTwo = new HashMap<UUID, Boolean>(); 
+    allowedUsersTwo.put(ownerTwo, true); 
+    allowedUsersTwo.put(ownerOne, false); 
     Conversation inputConversationTwo = new Conversation(idTwo, ownerTwo, titleTwo, creationTwo, typeTwo);
+    inputConversationTwo.addUser(ownerOne); 
+    inputConversationTwo.addAdmin(ownerTwo); 
 
     // save
     persistentDataStore.writeThrough(inputConversationOne);
@@ -112,6 +118,16 @@ public class PersistentDataStoreTest {
     Assert.assertEquals(titleTwo, resultConversationTwo.getTitle());
     Assert.assertEquals(creationTwo, resultConversationTwo.getCreationTime());
     Assert.assertEquals(typeTwo, resultConversationTwo.getType());
+    this.assertEquals(allowedUsersTwo, inputConversationTwo.getAllowedUsers()); 
+  }
+
+
+  // helper function to compare ACLs of conversations
+  private void assertEquals(HashMap<UUID, Boolean> allowedUsersOne, HashMap<UUID,  Boolean> allowedUsersTwo) {
+    Assert.assertEquals(allowedUsersOne.size(), allowedUsersTwo.size()); 
+    for (UUID id : allowedUsersOne.keySet()) {
+      assert(allowedUsersOne.get(id) == allowedUsersTwo.get(id)); 
+    }
   }
 
   @Test


### PR DESCRIPTION
Includes ability to store and test added users and admins in private conversations by creating another EmbeddedEntity for the Conversation entity in Datastore