### PR TITLE
Fixed Redirection and Permissions for Private Chats

### DIFF
--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -103,9 +103,25 @@ public class ChatServlet extends HttpServlet {
     HashMap<UUID, Boolean> allowedUsers = conversation.getAllowedUsers(); 
     List<String> allowedUsernames = new ArrayList<String>(); 
     if (conversation.getType().equals("private")) {
-      for (UUID id : allowedUsers.keySet()) {
-        allowedUsernames.add(userStore.getUser(id).getName()); 
-      }
+        
+        // User isn't logged in. Set error
+        if (request.getSession().getAttribute("user") == null)
+        {
+            request.setAttribute("error", "You do not have permissions to view this chat");
+        }
+        
+        else if (allowedUsers.containsKey(userStore.getUser((String)request.getSession().getAttribute("user")).getId()))
+        {
+            for (UUID id : allowedUsers.keySet()) 
+                allowedUsernames.add(userStore.getUser(id).getName()); 
+        }
+        
+        // User isn't part of the allowed group. Set error
+        else
+        {
+            request.setAttribute("error", "You do not have permissions to view this chat");
+        }
+            
     }
     else
       allowedUsernames = null; 

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -55,7 +55,11 @@ StylizedTextParser messageParser = new StylizedTextParser();
 <body onload="scrollChat()">
 
   <nav>
-   <a id="navTitle" href="/">Gossip Guru</a>
+  	<% if(request.getSession().getAttribute("user") != null){ %>
+		<a id="navTitle" href="/conversations">Gossip Guru</a>   
+	<% } else{ %>
+    	<a id="navTitle" href="/">Gossip Guru</a>
+   	<% } %>
    <a href="/conversations">Conversations</a>
    <% if(request.getSession().getAttribute("user") != null){ %>
      <a>Hello <%= request.getSession().getAttribute("user") %>!</a>

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -75,6 +75,9 @@ StylizedTextParser messageParser = new StylizedTextParser();
   </nav>
 
   <div id="container">
+   <% if(request.getAttribute("error") != null){ %>
+   		<h2 style="color:red"><%= request.getAttribute("error") %></h2>
+   <% } else { %>
 
     <h1><%= conversation.getTitle() %>
       <a href="" style="float: right">&#8635;</a></h1>
@@ -150,6 +153,7 @@ StylizedTextParser messageParser = new StylizedTextParser();
     <% } %>
 
     <hr/>
+  <% } %>
   </div>
 
 </body>

--- a/src/main/webapp/WEB-INF/view/conversations.jsp
+++ b/src/main/webapp/WEB-INF/view/conversations.jsp
@@ -25,7 +25,11 @@
 </head>
 <body>
   <nav>
-    <a id="navTitle" href="/">Gossip Guru</a>
+  	<% if(request.getSession().getAttribute("user") != null){ %>
+		<a id="navTitle" href="/conversations">Gossip Guru</a>   
+	<% } else{ %>
+    	<a id="navTitle" href="/">Gossip Guru</a>
+   	<% } %>
    <a href="/conversations">Conversations</a>
    <% if(request.getSession().getAttribute("user") != null){ %>
      <a>Hello <%= request.getSession().getAttribute("user") %>!</a>

--- a/src/main/webapp/WEB-INF/view/profile.jsp
+++ b/src/main/webapp/WEB-INF/view/profile.jsp
@@ -79,8 +79,12 @@ user.makeNotification("test", "hello user");
 <body>
 
  <nav>
-   <a id="navTitle" href="/">Gossip Guru</a>
-   <a href="/conversations">Conversations</a>
+	<% if(request.getSession().getAttribute("user") != null){ %>
+		<a id="navTitle" href="/conversations">Gossip Guru</a>   
+	<% } else{ %>
+    	<a id="navTitle" href="/">Gossip Guru</a>
+   	<% } %> 
+   	<a href="/conversations">Conversations</a>
    <% if(request.getSession().getAttribute("user") != null){ %>
    <a>Hello <%= request.getSession().getAttribute("user") %>!</a>
    <% } else{ %>


### PR DESCRIPTION
Originally clicking on "Gossip Guru" redirects you to the Login/Register page even if you are logged in. Changed so that if you are logged in and click the hyperlink, it redirects you to the conversation page. In the future it might be wise to create a dedicated home page.

Also, users that aren't logged in or users that aren't part of a group chat will be shown an error when they try to directly access a private page through a direct URL link. 